### PR TITLE
metanorma/metanorma-build-scripts#66 Drop ruby 2.4 support

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,4 +7,4 @@ inherit_from:
 # ...
 
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.5


### PR DESCRIPTION
As title. 

 _Generated by Cimas_.